### PR TITLE
Make the About Me subtitle not lowercase

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -118,6 +118,7 @@ h3 { font-size: var(--fs-h3); }
 
 .section__subtitle--intro {
     display: inline-block;
+    text-transform: lowercase;
 }
 
 .section__subtitle--intro,
@@ -127,7 +128,6 @@ h3 { font-size: var(--fs-h3); }
     padding: .25em 1em;
     font-family: var(--ff-secondary);
     margin-bottom: 1em;
-    text-transform: lowercase;
 }
 
 /* Navigation */


### PR DESCRIPTION
Received feedback that it stood out as weird that cleveland, ohio wasnt capitalized. So I changed this to be normal "correct" capitalization.